### PR TITLE
Add case-insensitive search

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -68,7 +68,7 @@ function search_courses_by_name($fromform) {
     // Search all courses except the frontpage (where category = 0).
     $searchquery = "SELECT id
                     FROM {course}
-                    WHERE fullname LIKE '%" . $fromform->search . "%' AND category != 0";
+                    WHERE LOWER(fullname) LIKE '%" . $fromform->search . "%' AND category != 0";
     // Apply filters.
     $searchquery .= search_filter($fromform);
     // Get courses from database.
@@ -81,7 +81,7 @@ function search_courses_by_summary($fromform) {
     // Search all courses except the frontpage (where category = 0).
     $searchquery = "SELECT id
                     FROM {course}
-                    WHERE summary LIKE '%" . $fromform->search . "%' AND category != 0";
+                    WHERE LOWER(summary) LIKE '%" . $fromform->search . "%' AND category != 0";
     // Apply filters.
     $searchquery .= search_filter($fromform);
     // Get courses from database.

--- a/view.php
+++ b/view.php
@@ -55,6 +55,8 @@ $form->display();
 $courserenderer = $PAGE->get_renderer('core', 'course');
 
 if ($fromform = $form->get_data()) {
+    // search term to lowercase to allow case-insensitive search
+    $fromform->search = strtolower($fromform->search);
     if ($fromform->combo_option == 'course') {
         $content = $courserenderer->courses_list(search_courses_by_name($fromform), true);
     }
@@ -66,7 +68,7 @@ if ($fromform = $form->get_data()) {
     }
 } else {
     $initialsearch = new stdClass();
-    $initialsearch->search = $search;
+    $initialsearch->search = strtolower($search);
     if ($option == 'course') {
         $content = $courserenderer->courses_list(search_courses_by_name($initialsearch), true);
     }


### PR DESCRIPTION
While using the plugin I came across an issue when searching for terms including capitalized letters in case the corresponding DB string was in all lower case or the other way around. Therefore I transformed the search param in the post body as well as the DB query to lowercase in order to match search terms to course names, categories and summaries regardless of the case-sensitivity.